### PR TITLE
make compatible with us-east-2

### DIFF
--- a/resources/vault/artifacts/upload/scripts/utils/env_defaults
+++ b/resources/vault/artifacts/upload/scripts/utils/env_defaults
@@ -11,3 +11,4 @@ export PATH=/opt/bin:$PATH:/opt/etc/vault/scripts
 interactive=${1:-'false'}
 
 BUCKET=$(grep bucket /opt/etc/vault/vault.hcl | grep -v ^# | awk '{print $NF}' | sed 's/"//g')
+REGION=$(grep region /opt/etc/vault/vault.hcl | grep -v ^# | awk '{print $NF}' | sed 's/"//g')

--- a/resources/vault/artifacts/upload/scripts/utils/functions
+++ b/resources/vault/artifacts/upload/scripts/utils/functions
@@ -26,11 +26,11 @@ check_vault() {
   fi
 }
 
-bucket_exist() { 
- docker run --rm xueshanf/awscli aws s3 ls s3://$BUCKET > /dev/null 2>&1
+bucket_exist() {
+ docker run --rm xueshanf/awscli aws s3 ls s3://$BUCKET --region $REGION > /dev/null 2>&1
 }
-s3ls() { 
- docker run --rm xueshanf/awscli aws s3 ls s3://$BUCKET/$1 > /dev/null 2>&1
+s3ls() {
+ docker run --rm xueshanf/awscli aws s3 ls s3://$BUCKET/$1 --region $REGION > /dev/null 2>&1
 }
 
 get_root_token() {

--- a/resources/vault/tf/main.tf
+++ b/resources/vault/tf/main.tf
@@ -16,7 +16,7 @@ module "vault" {
 
   # Instance specifications
   ami = "${data.aws_ami.coreos_ami.id}"
-  image_type = "m3.medium"
+  image_type = "t2.medium"
   keypair = "${var.cluster_name}-vault"
 
   # Note: currently vault launch_configuration devices can NOT be changed after vault cluster is up


### PR DESCRIPTION
- m3 instance types aren't available in us-east-2
- found that --region is required when listing s3 buckets in us-east-2