### PR TITLE
update command to verify UI container is ready

### DIFF
--- a/resources/add-ons/Makefile
+++ b/resources/add-ons/Makefile
@@ -80,7 +80,7 @@ dashboard: kube-system-admin-role-binding ## Start dashboard
 
 ui: dashboard ## kubectl proxy and open dashboard ui
 	kubectl proxy -p 8001 &> /dev/null &
-	@while ! kubectl get pods -n kube-system -o json -l app=kubernetes-dashboard  | grep ready | grep -q true ; \
+	@while ! kubectl get pods -n kube-system -o json -l k8s-app=kubernetes-dashboard | jq .items'[]'.status.containerStatuses'[]'.ready | grep -q true; \
 	do \
 		echo Waitting for UI ; \
 		sleep 10 ; \


### PR DESCRIPTION
When running make ui, I would get a constant loop of "Waiting for UI" - even though the UI was available if I went to https://127.0.0.1:8001/ui directly.

The problem was that the parameter for kubectl was `app=kubernetes-dashboard` instead of `k8s-app=kubernetes-dashboard`.

I also modified `|grep ready ` to `| jq .items'[]'.status.containerStatuses'[]'.ready` to ensure that the proper ready value was found.  I didn't think this would be a problem since jq is a prerequisite, and it makes it easier for me to understand what the command is looking for.